### PR TITLE
Bugfixes Round 2

### DIFF
--- a/calc/data/moves.js
+++ b/calc/data/moves.js
@@ -1163,8 +1163,7 @@ var DPP_PATCH = {
         type: 'Psychic',
         makesContact: true,
         category: 'Physical'
-    },
-    "Ground Pound":{type: "Ground",bp:85, category: "Physical"}
+    }
 };
 var DPP = (0, util_1.extend)(true, {}, ADV, DPP_PATCH);
 var BW_PATCH = {
@@ -1959,7 +1958,20 @@ var XY_PATCH = {
     'Sticky Web': { bp: 0, type: 'Bug' },
     'Topsy-Turvy': { bp: 0, type: 'Dark' },
     'Trick-or-Treat': { bp: 0, type: 'Ghost' },
-    'Venom Drench': { bp: 0, type: 'Poison', target: 'allAdjacentFoes' }
+    'Venom Drench': { bp: 0, type: 'Poison', target: 'allAdjacentFoes' },
+    'Ground Pound': {
+      bp: 85,
+      type: 'Ground',
+      category: 'Physical',
+      secondaries: true
+    },
+    'Grassy Dash': {
+      bp: 50,
+      type: 'Grass',
+      category: 'Physical',
+      priority: 1,
+      makesContact: true
+    }
 };
 var XY = (0, util_1.extend)(true, {}, BW, XY_PATCH);
 var SM_PATCH = {

--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -757,12 +757,12 @@ $(".forme").change(function () {
 	var chosenSet = pokemonSets && pokemonSets[setName];
 	var greninjaSet = $(this).val().indexOf("Greninja") !== -1;
 	var isAltForme = $(this).val() !== pokemonName;
-	if (isAltForme && abilities.indexOf(altForme.abilities[0]) !== -1 && !greninjaSet) {
+	if (chosenSet) {
+		container.find(".ability").val(chosenSet.ability);
+	} else if (isAltForme && abilities.indexOf(altForme.abilities[0]) !== -1 && !greninjaSet) {
 		container.find(".ability").val(altForme.abilities[0]);
 	} else if (greninjaSet) {
 		$(this).parent().find(".ability");
-	} else if (chosenSet) {
-		container.find(".ability").val(chosenSet.ability);
 	}
 	container.find(".ability").keyup();
 

--- a/js/showdown_hooks.js
+++ b/js/showdown_hooks.js
@@ -1068,6 +1068,8 @@ $(document).ready(function() {
             }
             pokedex[pok]["bs"] = jsonPok["bs"]
             pokedex[pok]["types"] = jsonPok["types"]
+            if (jsonPok.hasOwnProperty("abilities"))
+                pokedex[pok]["abilities"] = jsonPok["abilities"]
         }
         load_js() 
         customSets = JSON.parse(localStorage.customsets);
@@ -1158,14 +1160,17 @@ $(document).ready(function() {
 
 
 
-   $(document).on('click', '.trainer-pok.left-side', function() {
+    $(document).on('click', '.trainer-pok.left-side', function() {
         var set = $(this).attr('data-id')
         $('.player').val(set)
 
         $('.player').change()
         $('.player .select2-chosen').text(set)
+        if ($('.forme').is(':visible')) {
+            $('.forme').change()
+        }
         get_box()
-   })
+    })
 
    
 })


### PR DESCRIPTION
- Properly adds Grassy Dash in the movelist.
- Fixes forme shifting such that the Chosen Set ability will always be chosen first if there is one.
- Adds support for importing abilities in the "poks" list using npoint.
- Forces a refresh of the form & abilities when the user clicks on the their imported sets box.