### PR TITLE
Improving AX Calc

### DIFF
--- a/calc/data/moves.js
+++ b/calc/data/moves.js
@@ -2103,7 +2103,7 @@ var XY_PATCH = {
 			recoil: [33, 100]
 		},
 		'Smart Strike': {
-			bp: 75,
+			bp: 70,
 			type: 'Steel',
 			category: 'Physical',
 			makesContact: true

--- a/index.html
+++ b/index.html
@@ -1688,7 +1688,7 @@
     <script type="text/javascript" src="./calc/data/types.js?b935c17b"></script>
     <script type="text/javascript" src="./calc/data/natures.js?407b5243"></script>
     <script type="text/javascript" src="./calc/data/abilities.js?c1788575"></script>
-    <script type="text/javascript" src="./calc/data/moves.js?dcd8d225"></script>
+    <script type="text/javascript" src="./calc/data/moves.js?dcd8d226"></script>
     <script type="text/javascript" src="./calc/data/items.js?4724e4b2"></script>
     <script type="text/javascript" src="./calc/data/index.js?083d2bca"></script>
     <script type="text/javascript" src="./calc/move.js?de87e36d"></script>
@@ -1708,11 +1708,11 @@
     <script type="text/javascript" src="./calc/adaptable.js?afeb3759"></script>
     <script type="text/javascript" src="./calc/index.js?2377cbc8"></script>
 
-    <script type="text/javascript" src="./js/shared_controls.js?0b3ea060"></script>
+    <script type="text/javascript" src="./js/shared_controls.js?0b3ea061"></script>
 
 
     <script type="text/javascript" src="./js/index_randoms_controls.js?3375d6f7"></script>
-    <script type="text/javascript" src="./js/moveset_import.js?a7071f73"></script>
+    <script type="text/javascript" src="./js/moveset_import.js?a7071f74"></script>
 </div>
 
 

--- a/js/moveset_import.js
+++ b/js/moveset_import.js
@@ -1,25 +1,4 @@
 moveChanges = {
-	'Ancestral X': 
-		{
-			"Fury Attack"	:	"Scorching Swarm",
-			"Scratch"			:	"Breaking Swipe",
-			"Fairy Wind"	:	"Spirit Break",
-			"Vice Grip"		:	"Tussle",
-			"Wing Attack"	:	"Dual Wingbeat",
-			"Needle Arm"	:	"Trailblaze",
-			"Vine Whip"		:	"Trop Kick",
-			"Stomp"				:	"Ground Pound",
-			"Horn Attack"	:	"Headlong Rush",
-			"Powder Snow"	:	"Ice Hammer",
-			"Bind"				:	"Esper Wing",
-			"Rolling Kick":	"Fate's Flourish",
-			"Rock Throw"	:	"Accelerock",
-			"Crush Claw"	: "Smart Strike",
-			"Double Slap"	:	"Steel Beam",
-			"Lick"				:	"Aqua Step",
-			"Water Gun"		:	"Chilling Water",
-			"Pound"				:	"Wave Crash"
-		},
 	'Maximum Platinum': {
 		"Pound": "Hidden Power Grass",
 		"Payday": "Hidden Power Rock",

--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -1284,7 +1284,10 @@ $(".gen").change(function () {
 		pokedex = calc.SPECIES[gen];
 		console.log("loading defaults")
 		setdex = SETDEX[gen];
-		moves = calc.MOVES[9];
+		if (TITLE == "Ancestral X")
+			moves = calc.MOVES[6];
+		else
+			moves = calc.MOVES[9];
 		DEFAULTS_LOADED = true
 	}
 

--- a/js/showdown_hooks.js
+++ b/js/showdown_hooks.js
@@ -1310,7 +1310,7 @@ function loadDataSource(data) {
         moves[move]["bp"] = jsonMove["basePower"]
         MOVES_BY_ID[g][move_id].basePower = jsonMove["basePower"]
         
-        var optional_move_params = ["type", "category", "e_id", "multihit", "target", "recoil", "overrideBP"]  
+        var optional_move_params = ["type", "category", "e_id", "multihit", "target", "recoil", "overrideBP", "secondaries", "drain", "priority", "makesContact"]  
         for (n in optional_move_params) {
             var param = optional_move_params[n]
             if (jsonMove[param]) {
@@ -1493,7 +1493,7 @@ function loadDataSource(data) {
             console.log(moves[move])
         }
     }
-    moves['(No Move)'] = {
+    moves['(No Move)'] = moves['-'] = {
         "bp": 0,
         "category": "Status",
         "type": "Normal"


### PR DESCRIPTION
- Updating Smart Strike base power
- Removing import overrides as no longer necessary
- Swapping over to use gen 6 move list for AX instead of gen  9 (removing extra gen 7+ moves)
- Adding optional move params from npoint importing overrides.